### PR TITLE
Add Gemini provider support across stack

### DIFF
--- a/app/backend/routes/language_models.py
+++ b/app/backend/routes/language_models.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Any
 
 from app.backend.models.schemas import ErrorResponse
 from app.backend.services.ollama_service import OllamaService
-from src.llm.models import get_models_list
+from src.llm.models import get_models_list, get_provider_metadata
 
 router = APIRouter(prefix="/language-models")
 
@@ -42,15 +42,19 @@ async def get_language_model_providers():
     """Get the list of available model providers with their models grouped."""
     try:
         models = get_models_list()
-        
+
         # Group models by provider
         providers = {}
+        provider_metadata = get_provider_metadata()
         for model in models:
             provider_name = model["provider"]
+            metadata = provider_metadata.get(provider_name, {})
             if provider_name not in providers:
                 providers[provider_name] = {
                     "name": provider_name,
-                    "models": []
+                    "models": [],
+                    "capabilities": metadata.get("capabilities", {}),
+                    "api_key_env": metadata.get("api_key_env", []),
                 }
             providers[provider_name]["models"].append({
                 "display_name": model["display_name"],

--- a/app/frontend/src/components/settings/models/cloud.tsx
+++ b/app/frontend/src/components/settings/models/cloud.tsx
@@ -1,7 +1,8 @@
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import type { ProviderCapabilities } from '@/services/types';
 import { Cloud, RefreshCw } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 interface CloudModelsProps {
   className?: string;
@@ -10,19 +11,17 @@ interface CloudModelsProps {
 interface CloudModel {
   display_name: string;
   model_name: string;
-  provider: string;
 }
 
-interface ModelProvider {
+interface ProviderGroup {
   name: string;
-  models: Array<{
-    display_name: string;
-    model_name: string;
-  }>;
+  models: CloudModel[];
+  capabilities?: ProviderCapabilities;
+  api_key_env?: string[];
 }
 
 export function CloudModels({ className }: CloudModelsProps) {
-  const [providers, setProviders] = useState<ModelProvider[]>([]);
+  const [providers, setProviders] = useState<ProviderGroup[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -49,13 +48,65 @@ export function CloudModels({ className }: CloudModelsProps) {
     fetchProviders();
   }, []);
 
-  // Flatten all models from all providers into a single array
-  const allModels: CloudModel[] = providers.flatMap(provider =>
-    provider.models.map(model => ({
-      ...model,
-      provider: provider.name
-    }))
-  ).sort((a, b) => a.provider.localeCompare(b.provider));
+  const sortedProviders = useMemo(
+    () => [...providers].sort((a, b) => a.name.localeCompare(b.name)),
+    [providers]
+  );
+
+  const totalModels = useMemo(
+    () => providers.reduce((count, provider) => count + provider.models.length, 0),
+    [providers]
+  );
+
+  const renderCapabilityBadges = (capabilities?: ProviderCapabilities) => {
+    if (!capabilities) {
+      return null;
+    }
+
+    const badges: Array<{ key: string; label: string; className: string }> = [];
+
+    if (capabilities.supports_reasoning) {
+      badges.push({
+        key: 'reasoning',
+        label: 'Reasoning mode',
+        className: 'border-purple-500/40 bg-purple-500/10 text-purple-200',
+      });
+    }
+
+    if (capabilities.supports_json_mode === true) {
+      badges.push({
+        key: 'json-mode',
+        label: 'JSON mode',
+        className: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
+      });
+    }
+
+    if (capabilities.supports_json_mode === false) {
+      badges.push({
+        key: 'no-json-mode',
+        label: 'No JSON mode',
+        className: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
+      });
+    }
+
+    if (badges.length === 0) {
+      return null;
+    }
+
+    return (
+      <div className="flex flex-wrap gap-2">
+        {badges.map(badge => (
+          <Badge
+            key={badge.key}
+            variant="outline"
+            className={cn('text-xs font-medium', badge.className)}
+          >
+            {badge.label}
+          </Badge>
+        ))}
+      </div>
+    );
+  };
 
   return (
     <div className={cn("space-y-6", className)}>
@@ -77,7 +128,7 @@ export function CloudModels({ className }: CloudModelsProps) {
           <h3 className="font-medium text-primary
           ">Available Models</h3>
           <span className="text-xs text-muted-foreground">
-            {allModels.length} models from {providers.length} providers
+            {totalModels} models from {providers.length} providers
           </span>
         </div>
 
@@ -86,28 +137,51 @@ export function CloudModels({ className }: CloudModelsProps) {
             <RefreshCw className="h-8 w-8 mx-auto mb-2 animate-spin text-muted-foreground" />
             <p className="text-sm text-muted-foreground">Loading cloud models...</p>
           </div>
-        ) : allModels.length > 0 ? (
-          <div className="space-y-1">
-            {allModels.map((model) => (
-              <div 
-                key={`${model.provider}-${model.model_name}`}
-                className="group flex items-center justify-between bg-muted hover-bg rounded-md px-3 py-2.5 transition-colors"
+        ) : sortedProviders.length > 0 ? (
+          <div className="space-y-4">
+            {sortedProviders.map(provider => (
+              <div
+                key={provider.name}
+                className="rounded-lg border border-border/40 bg-muted/40 p-4 space-y-3"
               >
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium text-sm truncate text-primary">{model.display_name}</span>
-                    {model.model_name !== model.display_name && (
-                      <span className="font-mono text-xs text-muted-foreground">
-                        {model.model_name}
-                      </span>
-                    )}
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h4 className="font-semibold text-primary">{provider.name}</h4>
+                    {provider.api_key_env?.length ? (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        API key: {provider.api_key_env.join(' or ')}
+                      </p>
+                    ) : null}
                   </div>
+                  {renderCapabilityBadges(provider.capabilities)}
                 </div>
-                
-                <div className="flex items-center gap-2">
-                  <Badge className="text-xs text-primary bg-primary/10 border-primary/30 hover:bg-primary/20 hover:border-primary/50">
-                    {model.provider}
-                  </Badge>
+
+                {provider.capabilities?.notes?.length ? (
+                  <ul className="ml-1 list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+                    {provider.capabilities.notes.map(note => (
+                      <li key={note}>{note}</li>
+                    ))}
+                  </ul>
+                ) : null}
+
+                <div className="space-y-1">
+                  {provider.models.map(model => (
+                    <div
+                      key={`${provider.name}-${model.model_name}`}
+                      className="group flex items-center justify-between rounded-md bg-background/40 px-3 py-2.5 transition-colors hover:bg-background/60"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-sm truncate text-primary">{model.display_name}</span>
+                          {model.model_name !== model.display_name && (
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {model.model_name}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
                 </div>
               </div>
             ))}

--- a/app/frontend/src/data/models.ts
+++ b/app/frontend/src/data/models.ts
@@ -1,9 +1,11 @@
 import { api } from '@/services/api';
+import type { ModelProvider, ProviderCapabilities } from '@/services/types';
 
 export interface LanguageModel {
   display_name: string;
   model_name: string;
-  provider: "Anthropic" | "DeepSeek" | "Google" | "Groq" | "OpenAI";
+  provider: ModelProvider | string;
+  capabilities?: ProviderCapabilities;
 }
 
 // Cache for models to avoid repeated API calls

--- a/app/frontend/src/services/types.ts
+++ b/app/frontend/src/services/types.ts
@@ -1,9 +1,26 @@
 // Shared types for API requests and responses
 export enum ModelProvider {
-  OPENAI = 'OpenAI',
+  ALIBABA = 'Alibaba',
   ANTHROPIC = 'Anthropic',
+  AZURE_OPENAI = 'Azure OpenAI',
+  DEEPSEEK = 'DeepSeek',
+  GEMINI = 'Gemini',
+  GOOGLE = 'Google',
+  GIGACHAT = 'GigaChat',
   GROQ = 'Groq',
+  META = 'Meta',
+  MISTRAL = 'Mistral',
   OLLAMA = 'Ollama',
+  OPENAI = 'OpenAI',
+  OPENROUTER = 'OpenRouter',
+  XAI = 'xAI',
+}
+
+export interface ProviderCapabilities {
+  supports_json_mode?: boolean;
+  supports_reasoning?: boolean;
+  notes?: string[];
+  api_key_env?: string[];
 }
 
 export interface AgentModelConfig {

--- a/src/llm/api_models.json
+++ b/src/llm/api_models.json
@@ -52,12 +52,12 @@
   {
     "display_name": "Gemini 2.5 Flash",
     "model_name": "gemini-2.5-flash-preview-05-20",
-    "provider": "Google"
+    "provider": "Gemini"
   },
   {
     "display_name": "Gemini 2.5 Pro",
     "model_name": "gemini-2.5-pro-preview-06-05",
-    "provider": "Google"
+    "provider": "Gemini"
   },
   {
     "display_name": "GLM-4.5 Air",


### PR DESCRIPTION
## Summary
- add a Gemini provider to the shared LLM model registry with capability metadata, API key fallbacks, and Google Generative AI routing
- surface Gemini-specific handling in the CLI, backend provider listing, and API model catalog so metadata round-trips cleanly
- update frontend types and the cloud models settings UI to show Gemini as a distinct provider with capability hints

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68dcf39cc120832eaae3bb3c886e2749