### PR TITLE
Handle missing scheme in Ibbot host configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,10 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 AZURE_OPENAI_API_KEY=your-azure-openai-api-key
 AZURE_OPENAI_ENDPOINT=your-azure-openai-endpoint
 AZURE_OPENAI_DEPLOYMENT_NAME=your-azure-openai-deployment-name
+
+# For integrating with ibbot (Interactive Brokers Bot)
+# Include the scheme or port if needed (e.g. localhost:5000 will default to http)
+IBBOT_HOST=localhost:5000
+IBBOT_ACCOUNT=your-ibbot-account
+IBBOT_ACCESS_TOKEN=your-ibbot-access-token
+IBBOT_REFRESH_TOKEN=your-ibbot-refresh-token

--- a/README.md
+++ b/README.md
@@ -92,7 +92,16 @@ Interactive Brokers Bot (ibbot) packaging adds an execution-ready hand-off to ev
 - `IBBOT_ACCESS_TOKEN`
 - `IBBOT_REFRESH_TOKEN`
 
-These values allow the platform to authenticate with ibbot and upload the packaged strategy bundle. If you're running inside Docker, follow the [container-specific setup instructions](docker/README.md#ibbot-in-docker) first so the compose services receive the credentials.
+These values allow the platform to authenticate with ibbot and upload the packaged strategy bundle. For local ibbot instances you can include the port in the host value, for example:
+
+```bash
+IBBOT_HOST=localhost:5000
+IBBOT_ACCOUNT=paper-trading
+IBBOT_ACCESS_TOKEN=your-access-token
+IBBOT_REFRESH_TOKEN=your-refresh-token
+```
+
+If you're running inside Docker, follow the [container-specific setup instructions](docker/README.md#ibbot-in-docker) first so the compose services receive the credentials.
 
 To direct the system to use ibbot pricing and generate an intraday package:
 

--- a/src/data/providers/ibbot.py
+++ b/src/data/providers/ibbot.py
@@ -51,7 +51,18 @@ class IbbotDataProvider(MarketDataProvider):
 
     @property
     def _base_url(self) -> str:
-        return self.host.rstrip("/")
+        host = str(self.host).strip().rstrip("/")
+        if not host:
+            raise ValueError("Ibbot host is empty")
+
+        if "://" not in host:
+            normalized_host = host.lstrip("/")
+            if normalized_host.startswith(("localhost", "127.0.0.1", "0.0.0.0")):
+                host = f"http://{normalized_host}"
+            else:
+                host = f"https://{normalized_host}"
+
+        return host
 
     def _auth_headers(self) -> dict[str, str]:
         return {


### PR DESCRIPTION
## Summary
- normalize Ibbot host configuration to ensure a valid URL scheme is present
- default localhost-style hosts to http while other hosts default to https
- raise a clear error when the resolved host value is empty

## Testing
- poetry run pytest *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68ddcbe67e6c832e94263dd8d8dc3dfc